### PR TITLE
Enable alternative package_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You have attributes to override if you want some tuneables:
 
 - `default['chefdk']['version']` - specify a version defaults to `latest`
 - `default['chefdk']['channel']` - specify a channel `stable`, `current`, `unstable`
+- `default['chefdk']['package_source']` - specify an alternative package source - defaults to `nil`
+     Full path to a location where the package is located. If present, this file is used for installing the package.
 
 ## Contributing
 1. Fork the repository on Github

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,4 +10,5 @@ chef_ingredient 'chefdk' do
   action :install
   version node['chefdk']['version']
   channel node['chefdk']['channel']
+  package_source node['chefdk']['package_source']
 end


### PR DESCRIPTION
If installing chefdk from inside an isolated network we need to be able to specify an alternative package_source for chef-ingredient to use - such as an rpm file.